### PR TITLE
Hide internal API from consumers

### DIFF
--- a/src/baseComponent.ts
+++ b/src/baseComponent.ts
@@ -2,11 +2,29 @@ import Maid from "@rbxts/maid";
 import Signal from "@rbxts/signal";
 
 /**
+ * @hidden @internal
+ */
+export const SYMBOL_ATTRIBUTE_HANDLERS: unique symbol = {} as never;
+
+/**
+ * @hidden @deprecated
+ */
+export const SYMBOL_ATTRIBUTE_SETTER: unique symbol = {} as never;
+
+/**
  * This is the base component class which handles instance guards, attribute guards and cleanup.
  *
  * You should not construct this class manually, and all components must extend this class.
  */
 export class BaseComponent<A = {}, I extends Instance = Instance> {
+	/**
+	 * @hidden @internal
+	 */
+	public static setInstance<A, I extends Instance>(component: BaseComponent<A, I>, instance: I, attributes: unknown) {
+		component.instance = instance;
+		component.attributes = attributes as never;
+	}
+
 	/**
 	 * A maid that will be destroyed when the component is.
 	 */
@@ -23,20 +41,16 @@ export class BaseComponent<A = {}, I extends Instance = Instance> {
 	 */
 	public instance!: I;
 
-	setInstance(instance: I, attributes: unknown) {
-		this.instance = instance;
-		this.attributes = attributes as never;
-	}
-
-	setAttribute<T extends keyof A>(key: T, value: A[T], postfix?: boolean) {
+	/** @hidden @deprecated */
+	public [SYMBOL_ATTRIBUTE_SETTER]<T extends keyof A>(key: T, value: A[T], postfix?: boolean) {
 		const previousValue = this.attributes[key];
 		this.attributes[key] = value;
 		this.instance.SetAttribute(key as string, value as never);
 		return postfix ? previousValue : value;
 	}
 
-	/** @hidden */
-	public _attributeChangeHandlers = new Map<string, Signal<(newValue: unknown, oldValue: unknown) => void>>();
+	/** @hidden @internal */
+	public [SYMBOL_ATTRIBUTE_HANDLERS] = new Map<string, Signal<(newValue: unknown, oldValue: unknown) => void>>();
 
 	/**
 	 * Connect a callback to the change of a specific attribute.
@@ -44,8 +58,8 @@ export class BaseComponent<A = {}, I extends Instance = Instance> {
 	 * @param cb The callback
 	 */
 	onAttributeChanged<K extends keyof A>(name: K, cb: (newValue: A[K], oldValue: A[K]) => void) {
-		let list = this._attributeChangeHandlers.get(name as string);
-		if (!list) this._attributeChangeHandlers.set(name as string, (list = new Signal()));
+		let list = this[SYMBOL_ATTRIBUTE_HANDLERS].get(name as string);
+		if (!list) this[SYMBOL_ATTRIBUTE_HANDLERS].set(name as string, (list = new Signal()));
 
 		return list.Connect(cb as never);
 	}
@@ -55,7 +69,7 @@ export class BaseComponent<A = {}, I extends Instance = Instance> {
 	 */
 	destroy() {
 		this.maid.Destroy();
-		for (const [, changeHandler] of this._attributeChangeHandlers) {
+		for (const [, changeHandler] of this[SYMBOL_ATTRIBUTE_HANDLERS]) {
 			changeHandler.Destroy();
 		}
 	}

--- a/src/baseComponent.ts
+++ b/src/baseComponent.ts
@@ -22,7 +22,7 @@ export class BaseComponent<A = {}, I extends Instance = Instance> {
 	 */
 	public static setInstance<A, I extends Instance>(component: BaseComponent<A, I>, instance: I, attributes: unknown) {
 		component.instance = instance;
-		component.attributes = attributes as never;
+		component.attributes = attributes as A;
 	}
 
 	/**

--- a/src/components.ts
+++ b/src/components.ts
@@ -1,7 +1,7 @@
 import { Controller, Flamework, Modding, OnInit, OnStart, Reflect, Service } from "@flamework/core";
 import { CollectionService, ReplicatedStorage, RunService, ServerStorage } from "@rbxts/services";
 import { t } from "@rbxts/t";
-import { BaseComponent } from "./baseComponent";
+import { BaseComponent, SYMBOL_ATTRIBUTE_HANDLERS } from "./baseComponent";
 import { ComponentTracker } from "./componentTracker";
 import { Constructor, getComponentFromSpecifier, getIdFromSpecifier, getParentConstructor, safeCall } from "./utility";
 
@@ -287,7 +287,7 @@ export class Components implements OnInit, OnStart {
 		construct: () => void,
 		{ ctor }: ComponentInfo,
 	) {
-		component.setInstance(instance, attributes);
+		BaseComponent.setInstance(component, instance, attributes);
 		construct();
 
 		if (Flamework.implements<OnStart>(component)) {
@@ -308,7 +308,7 @@ export class Components implements OnInit, OnStart {
 				if (typeIs(attribute, "string")) {
 					component.maid.GiveTask(
 						instance.GetAttributeChangedSignal(attribute).Connect(() => {
-							const signal = component._attributeChangeHandlers.get(attribute);
+							const signal = component[SYMBOL_ATTRIBUTE_HANDLERS].get(attribute);
 							const value = instance.GetAttribute(attribute);
 							const attributes = component.attributes as Map<string, unknown>;
 							if (guard(value)) {


### PR DESCRIPTION
BREAKING: `setInstance`, `setAttribute` and `_attributeChangeHandlers` are no longer exposed.