### PR TITLE
Add component streaming modes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { BaseComponent } from "./baseComponent";
-export { Components, ComponentConfig, Component } from "./components";
+export { Components, ComponentConfig, ComponentStreamingMode, Component } from "./components";


### PR DESCRIPTION
BREAKING: By default, components on the client will no longer watch for hierarchy changes on `Atomic` models. This behavior can be adjusted with the new `streamingMode` field in the component config.